### PR TITLE
fix: Correct type check in ComponentGraph sanity_check

### DIFF
--- a/epowcore/generic/component_graph.py
+++ b/epowcore/generic/component_graph.py
@@ -149,7 +149,7 @@ class ComponentGraph:
         data_values = [
             a for b in map(lambda edge: list(edge[2].values()), self._graph.edges.data()) for a in b
         ]
-        edge_type_check = all(isinstance(x, list) for x in data_keys) and all(
+        edge_type_check = all(isinstance(x, int) for x in data_keys) and all(
             isinstance(x, list) for x in data_values
         )
 

--- a/epowcore/generic/component_views.py
+++ b/epowcore/generic/component_views.py
@@ -52,7 +52,7 @@ class ComponentEdgeView:
     """
 
     def __init__(
-        self, edge_view: nx.classes.reportviews.EdgeView
+        self, edge_view: nx.classes.reportviews.EdgeView | nx.classes.reportviews.OutEdgeView
     ) -> None:
         self._edge_view = edge_view
 


### PR DESCRIPTION
Fixes a bug where `CoreModel.sanity_check()` always returns `False` for valid models. 

## Motivation and Context
While tracing model validity, I noticed that successful model conversions were failing the `CoreModel.sanity_check()`. Upon investigation, the validation step inside `ComponentGraph.sanity_check()` was checking if the keys of the edge data dictionary were of type `list`. 

Since `CoreModel.add_connection()` maps component `uid`s (`int`) to connector names (`list`), checking the keys against `list` always evaluated to `False`. 

## Changes Made
- Updated `ComponentGraph.sanity_check()` in `epowcore/generic/component_graph.py` to correctly evaluate edge dictionary keys as `int`.

## Testing
- Verified that empty graphs and graphs with connected components now accurately pass or fail the sanity check based on their actual validity. 
- Existing test suites run successfully.
