### PR TITLE
Fix basic behavior for the sanity_check method

### DIFF
--- a/epowcore/gdf/core_model.py
+++ b/epowcore/gdf/core_model.py
@@ -1,9 +1,10 @@
-from ast import literal_eval as make_tuple
-from dataclasses import dataclass, field, asdict
 import importlib
+from ast import literal_eval as make_tuple
+from dataclasses import asdict, dataclass, field
 from typing import TypeVar
 
 import networkx as nx
+
 from epowcore.generic.component_graph import ComponentGraph
 from epowcore.generic.configuration import Configuration
 from epowcore.generic.constants import GDF_VERSION, Platform
@@ -269,8 +270,8 @@ class CoreModel:
         :return: A list of components connected to to given [component].
         :rtype: list[Component]
         """
-        from epowcore.gdf.subsystem import Subsystem
         from epowcore.gdf.port import Port
+        from epowcore.gdf.subsystem import Subsystem
 
         _, graph = self.get_component_by_id(component.uid)
         if graph is None:
@@ -339,6 +340,12 @@ class CoreModel:
         :return: True if the model is valid, else False.
         """
 
+        def check_neighbors(node: Component, connector_name: str) -> bool:
+            try:
+                return self.get_neighbors(node, True, connector_name) != []
+            except KeyError:
+                return False
+
         graph_sanity = self.graph.sanity_check()
         # Check if the edges have the required connectors
         connector_check = all(
@@ -346,7 +353,7 @@ class CoreModel:
                 lambda node: len(node.connector_names) == 0
                 or all(
                     map(
-                        lambda x: self.has_connected_to(node, x),
+                        lambda x: check_neighbors(node, x),
                         node.connector_names,
                     )
                 ),

--- a/epowcore/generic/component_graph.py
+++ b/epowcore/generic/component_graph.py
@@ -1,11 +1,12 @@
-from collections.abc import Iterable
 import copy as cp
+from collections.abc import Iterable
 from functools import cached_property
+from pprint import pp
 from typing import Iterator
 
 import networkx as nx
-from epowcore.gdf.component import Component
 
+from epowcore.gdf.component import Component
 from epowcore.generic.component_views import ComponentEdgeView, ComponentNodeView
 
 
@@ -141,16 +142,22 @@ class ComponentGraph:
         """
         # Check the types of the components
         node_type_check = all(isinstance(node, Component) for node in self._graph.nodes)
+        print(f"node_type_check: {node_type_check}")
 
-        # Check the types of the edge data
-        data_keys = [
-            a for b in map(lambda edge: list(edge[2].keys()), self._graph.edges.data()) for a in b
-        ]
-        data_values = [
-            a for b in map(lambda edge: list(edge[2].values()), self._graph.edges.data()) for a in b
-        ]
-        edge_type_check = all(isinstance(x, list) for x in data_keys) and all(
-            isinstance(x, list) for x in data_values
+        # The edge data ist a list of tuples,
+        # each tuple contains the two components on index 0 and 1 and a dictionary on index 2.
+        # This dictionary maps the integer uid of both components each to a list of connector name strings.
+        # The different connectors are connected in order of the lists.
+        # The goal of the following code is to verify the value types of the dictionary.
+        edge_data = list(self._graph.edges.data())
+        data_components = [item for tuple in edge_data for item in tuple[:2]]
+        data_keys = [a for b in map(lambda edge: list(edge[2].keys()), edge_data) for a in b]
+        data_values = [a for b in map(lambda edge: list(edge[2].values()), edge_data) for a in b]
+        edge_type_check = (
+            all(isinstance(component, Component) for component in data_components)
+            and all(isinstance(edge, tuple) for edge in edge_data)
+            and all(isinstance(x, int) for x in data_keys)
+            and all(isinstance(x, list) and all(isinstance(y, str) for y in x) for x in data_values)
         )
 
         return node_type_check and edge_type_check

--- a/tests/core/gdf/utils_test.py
+++ b/tests/core/gdf/utils_test.py
@@ -1,11 +1,16 @@
+import json
+import os
 import pathlib
+import sys
 import unittest
+from zipfile import Path
 
 from helpers.gdf_component_creator import GdfTestComponentCreator
 
 from epowcore.gdf.bus import Bus, LFBusType
 from epowcore.gdf.core_model import CoreModel
 from epowcore.gdf.utils import get_connected_bus
+from epowcore.generic.manipulation.flatten import flatten
 
 PATH = pathlib.Path(__file__).parent.resolve()
 
@@ -32,6 +37,43 @@ class UtilsTest(unittest.TestCase):
 
         bus = get_connected_bus(core_model.graph, tline)
         self.assertIn(bus, (bus_a, bus_b))
+
+    def test_sanity_check_IEEE39(self) -> None:
+        PATH = pathlib.Path(__file__).parent.parent.resolve()
+
+        with open(
+            PATH.parent.parent / "tests/models/gdf/IEEE39_gdf.json", "r", encoding="utf-8"
+        ) as file:
+            data_str = file.read()
+            data = json.loads(data_str)
+            core_model = CoreModel.import_dict(data)
+            # flatten(core_model)  # if the mode lis flattened this also fails
+
+        assert core_model.sanity_check()
+
+    def test_sanity_check_IEEE39_flat(self) -> None:
+        PATH = pathlib.Path(__file__).parent.parent.resolve()
+
+        with open(
+            PATH.parent.parent / "tests/models/gdf/IEEE39-flat_gdf.json", "r", encoding="utf-8"
+        ) as file:
+            data_str = file.read()
+            data = json.loads(data_str)
+            core_model = CoreModel.import_dict(data)
+
+        assert core_model.sanity_check()
+
+    # def test_sanity_check_IEEE9(self) -> None:
+    #    PATH = pathlib.Path(__file__).parent.parent.resolve()
+
+    #    with open(
+    #        PATH.parent.parent / "tests/models/gdf/IEEE9_gdf.json", "r", encoding="utf-8"
+    #    ) as file:
+    #        data_str = file.read()
+    #        data = json.loads(data_str)
+    #        core_model = CoreModel.import_dict(data)
+
+    #    assert core_model.sanity_check()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This partially fixed the sanity_check method for the core_model class.

It still has the problem that it does not check subsystems and their graphs, which is the only reason that the IEEE39 test passes.

Otherwise they fail, most likely due to an error in the import process of PowerFactory models (which is how the example models were generated), where on the connections between Exciters, Governors, and Stabilizers Connection-Ports are missing.

Closes #8 
