### PR TITLE
Added low-voltage load type

### DIFF
--- a/epowcore/gdf/load.py
+++ b/epowcore/gdf/load.py
@@ -1,14 +1,25 @@
 from dataclasses import dataclass, field
+from enum import Enum
 
 from .component import Component
 
 
+class LoadType(Enum):
+    """Defines the type of a load."""
+
+    GENERAL = "General"
+    LOW_VOLTAGE = "Low Voltage"
+
+
 @dataclass(unsafe_hash=True, kw_only=True)
 class Load(Component):
-    """This class represents an general Load. Specific kinds
-    of loads are not taken into account currently."""
+    """This class represents a load."""
 
     active_power: float = field(default_factory=float)
-    """The active power of the Load. The unit is MW."""
+    """The active power of the load. The unit is MW."""
+
     reactive_power: float = field(default_factory=float)
-    """The reactive Power of the Load. The unit is Mvar."""
+    """The reactive power of the load. The unit is Mvar."""
+
+    load_type: LoadType = LoadType.GENERAL
+    """The load type. General load is used by default."""

--- a/epowcore/power_factory/to_gdf/components/load.py
+++ b/epowcore/power_factory/to_gdf/components/load.py
@@ -1,12 +1,13 @@
 from math import acos, tan
+
 import powerfactory as pf
 
-from epowcore.gdf.load import Load
+from epowcore.gdf.load import Load, LoadType
 from epowcore.power_factory.utils import get_coords
 
 
 def create_load(pf_load: pf.DataObject, uid: int) -> Load:
-    """Sets the attributes of Load from a PowerFactory load"""
+    """Sets the attributes of Load from a PowerFactory load."""
 
     return Load(
         uid,
@@ -18,7 +19,7 @@ def create_load(pf_load: pf.DataObject, uid: int) -> Load:
 
 
 def create_load_lv(pf_load: pf.DataObject, uid: int) -> Load:
-    """Sets the attributes of Load from a PowerFactory load"""
+    """Sets the attributes of a low-voltage Load from a PowerFactory load."""
 
     active_power = pf_load.plini_a / 1000
 
@@ -28,4 +29,5 @@ def create_load_lv(pf_load: pf.DataObject, uid: int) -> Load:
         get_coords(pf_load),
         active_power=active_power,
         reactive_power=active_power * tan(acos(pf_load.coslini_a)),
+        load_type=LoadType.LOW_VOLTAGE,
     )

--- a/tests/core/gdf/load_type_test.py
+++ b/tests/core/gdf/load_type_test.py
@@ -1,0 +1,24 @@
+from epowcore.gdf.load import Load, LoadType
+
+
+def test_load_uses_general_type_by_default() -> None:
+    load = Load(
+        1,
+        "General Load",
+        active_power=1.0,
+        reactive_power=0.2,
+    )
+
+    assert load.load_type is LoadType.GENERAL
+
+
+def test_load_can_be_created_as_low_voltage() -> None:
+    load = Load(
+        2,
+        "Low Voltage Load",
+        active_power=0.1,
+        reactive_power=0.02,
+        load_type=LoadType.LOW_VOLTAGE,
+    )
+
+    assert load.load_type is LoadType.LOW_VOLTAGE


### PR DESCRIPTION
Adds an explicit low-voltage load type to the GDF Load model.

- Keeps the existing general load type as the default
- Adds LoadType.LOW_VOLTAGE
- Marks PowerFactory low-voltage loads imported through create_load_lv()
- Adds tests for default and explicit load types

Tests:
- 2 load-type tests passed
- 20 GDF tests passed, 1 skipped

Closes #6