### PR TITLE
Fix  PowerFactory controller connection metadata

### DIFF
--- a/epowcore/power_factory/to_gdf/power_factory_extractor.py
+++ b/epowcore/power_factory/to_gdf/power_factory_extractor.py
@@ -281,7 +281,7 @@ class PowerFactoryExtractor:
             self.uid += 1
             self._component_dict[pf_switch] = switch
             self.graph.add_node(pf_switch)
-    
+
     def extract_fuses(self) -> None:
         """Extract the PowerFactory fuses to the data format. Currently represented as a switch for the gdf"""
         pf_fuses = self.app.GetCalcRelevantObjects("RelFuse")
@@ -322,7 +322,12 @@ class PowerFactoryExtractor:
             self._component_dict[pss] = generic_pss
             self.graph.add_node(pss)
             # Create edge with the appropriate generator
-            self.graph.add_edge(pss, generator)
+            self.graph.edges[pss, generator].update(
+                {
+                    generic_pss.uid: generic_pss.connector_names.copy(),
+                    self._component_dict[generator].uid: [],
+                }
+            )
 
     def select_avr_type(self, generator: Any) -> None:
         """Selects one of the currently supported Exciter to extract"""
@@ -347,7 +352,12 @@ class PowerFactoryExtractor:
             self._component_dict[avr] = generic_avr
             self.graph.add_node(avr)
             # Create edge with the appropriate generator
-            self.graph.add_edge(avr, generator)
+            self.graph.edges[avr, generator].update(
+                {
+                    generic_avr.uid: generic_avr.connector_names.copy(),
+                    self._component_dict[generator].uid: [],
+                }
+            )
 
     def select_gov_type(self, generator: Any) -> None:
         """Selects one of the currently supported Governor to extract"""
@@ -381,7 +391,12 @@ class PowerFactoryExtractor:
             self._component_dict[gov] = generic_gov
             self.graph.add_node(gov)
             # Create edge with the appropriate generator
-            self.graph.add_edge(gov, generator)
+            self.graph.edges[gov, generator].update(
+                {
+                    generic_gov.uid: generic_gov.connector_names.copy(),
+                    self._component_dict[generator].uid: [],
+                }
+            )
 
     def set_core_model_graph(self) -> None:
         """This creates the graph for the GenericCoreModel"""

--- a/epowcore/power_factory/to_gdf/power_factory_extractor.py
+++ b/epowcore/power_factory/to_gdf/power_factory_extractor.py
@@ -322,6 +322,7 @@ class PowerFactoryExtractor:
             self._component_dict[pss] = generic_pss
             self.graph.add_node(pss)
             # Create edge with the appropriate generator
+            self.graph.add_edge(pss, generator)
             self.graph.edges[pss, generator].update(
                 {
                     generic_pss.uid: generic_pss.connector_names.copy(),
@@ -352,6 +353,7 @@ class PowerFactoryExtractor:
             self._component_dict[avr] = generic_avr
             self.graph.add_node(avr)
             # Create edge with the appropriate generator
+            self.graph.add_edge(avr, generator)
             self.graph.edges[avr, generator].update(
                 {
                     generic_avr.uid: generic_avr.connector_names.copy(),
@@ -391,6 +393,7 @@ class PowerFactoryExtractor:
             self._component_dict[gov] = generic_gov
             self.graph.add_node(gov)
             # Create edge with the appropriate generator
+            self.graph.add_edge(gov, generator)
             self.graph.edges[gov, generator].update(
                 {
                     generic_gov.uid: generic_gov.connector_names.copy(),

--- a/tests/power_factory/pf_converter_test.py
+++ b/tests/power_factory/pf_converter_test.py
@@ -1,4 +1,8 @@
 import unittest
+
+from epowcore.gdf.exciters.exciter import Exciter
+from epowcore.gdf.governors.governor import Governor
+from epowcore.gdf.power_system_stabilizers.power_system_stabilizer import PowerSystemStabilizer
 from epowcore.gdf.transformers.two_winding_transformer import TwoWindingTransformer
 from epowcore.power_factory.power_factory_converter import PFModel, PowerFactoryConverter
 
@@ -10,21 +14,34 @@ class PFConverterTest(unittest.TestCase):
         """Test if the CoreModel extraction from the Minimal PF model throws errors."""
         converter = PowerFactoryConverter()
         core_model = converter.to_gdf(PFModel("Minimal", "Base", 50.0))
+
         self.assertEqual(len(core_model.graph.nodes), 8)
         self.assertEqual(len(core_model.graph.edges), 7)
+
         two_winding_id = core_model.type_list(TwoWindingTransformer)[0].uid
+
         self.assertTrue(
             any(
                 two_winding_id in x[2] and x[2][two_winding_id] == ["HV"]
                 for x in core_model.graph.edges.data()
             )
         )
+
         self.assertTrue(
             any(
                 two_winding_id in x[2] and x[2][two_winding_id] == ["LV"]
                 for x in core_model.graph.edges.data()
             )
         )
+
+        for controller_type in (Exciter, Governor, PowerSystemStabilizer):
+            controller = core_model.type_list(controller_type)[0]
+            self.assertTrue(
+                any(
+                    controller.uid in edge_data and edge_data[controller.uid] == ["In", "Out"]
+                    for _, _, edge_data in core_model.graph.edges.data()
+                )
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes missing connector metadata for PowerFactory-imported generator controls.

Changes:
- Adds connector metadata for exciter/AVR connections
- Adds connector metadata for governor connections
- Adds connector metadata for PSS connections
- Adds a regression test for the Minimal PowerFactory model

The controller components already existed, but their edge dictionaries did not contain the required connector names.

Tests:
- pre-commit passed
- 20 GDF tests passed, 1 skipped
- PowerFactory integration test could not be run locally because the proprietary `powerfactory` Python module is not available

Closes #16