### PR TITLE
Move black and isort settings to pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,8 @@ repos:
   rev: 5.12.0
   hooks:
   - id: isort
-    args: ["--profile", "black", "--line-length", "100"]
+
 - repo: https://github.com/psf/black
   rev: 24.10.0
   hooks:
   - id: black
-    args: ["--line-length", "100"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,10 @@ repos:
   rev: 5.12.0
   hooks:
   - id: isort
+    args: ["--settings-path", "pyproject.toml"]
 
 - repo: https://github.com/psf/black
   rev: 24.10.0
   hooks:
   - id: black
+    args: ["--config", "pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,10 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 include = ["epowcore", "epowcore.*"]
+
+[tool.black]
+line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100


### PR DESCRIPTION
- pyproject.toml now stores the Black/isort settings.
- .pre-commit-config.yaml still runs Black and isort, but no longer repeats their options.
- Pre-commit automatically reads the settings from pyproject.toml.