### PR TITLE
Fixed sanity check for edge metadata

### DIFF
--- a/epowcore/generic/component_graph.py
+++ b/epowcore/generic/component_graph.py
@@ -149,7 +149,7 @@ class ComponentGraph:
         data_values = [
             a for b in map(lambda edge: list(edge[2].values()), self._graph.edges.data()) for a in b
         ]
-        edge_type_check = all(isinstance(x, list) for x in data_keys) and all(
+        edge_type_check = all(isinstance(x, int) for x in data_keys) and all(
             isinstance(x, list) for x in data_values
         )
 

--- a/tests/core/generic/component_graph_test.py
+++ b/tests/core/generic/component_graph_test.py
@@ -174,6 +174,14 @@ class ComponentGraphTest(unittest.TestCase):
         self.assertEqual(len(edges_with_1), 1)
         self.assertIn(node1, edges_with_1[0])
 
+    def test_sanity_check_with_edge_data(self) -> None:
+        tgraph = ComponentGraph()
+        node1 = Component(0, "One", None)
+        node2 = Component(1, "Two", None)
+        tgraph.add_edge(node1, node2)
+        tgraph.edges.update(node1, node2, {0: ["A"], 1: ["B"]})
+
+        self.assertTrue(tgraph.sanity_check())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #8.

The sanity check incorrectly expected edge-data keys to be lists, although they are component UIDs (`int`). This caused valid converted models to fail the sanity check.

Changes:
- validate edge-data keys as `int`
- add a regression test with valid edge metadata

Tests:
- `python -m pytest tests/core/generic/component_graph_test.py -vv`
- 16 passed