### PR TITLE
Handle missing connections in PowerFactory and pandapower exports

### DIFF
--- a/epowcore/pandapower/pandapower_model.py
+++ b/epowcore/pandapower/pandapower_model.py
@@ -529,6 +529,9 @@ class PandapowerModel:
         ward_bus = get_connected_bus(core_model.graph, ward, max_depth=1)
         # If there was no ward_bus found the function failed and terminates
         if ward_bus is None:
+            Logger.log_to_selected(
+                f"There was no bus found connected to ward {ward.name}"
+            )
             return False
         # Create ward in pandapower network
         pandapower.create_ward(
@@ -561,6 +564,9 @@ class PandapowerModel:
         shunt_bus = get_connected_bus(core_model.graph, shunt, max_depth=1)
         # If there was no shunt_bus found the function failed and terminates
         if shunt_bus is None:
+            Logger.log_to_selected(
+                f"There was no bus found connected to shunt {shunt.name}"
+            )
             return False
         # Create shunt in pandapower network
         pandapower.create_shunt(
@@ -621,6 +627,9 @@ class PandapowerModel:
                 switch_bus = neighbours[1]
                 switch_other_component = neighbours[0]
         else:
+            Logger.log_to_selected(
+                f"Failed to convert {switch.name} because fewer than two connections were found"
+            )
             return False
         # Get string mapped to the type of the other component
         switch_et = self._create_pandapower_switch_et(switch_other_component)
@@ -667,6 +676,9 @@ class PandapowerModel:
                 switch_bus = neighbours[1]
                 switch_other_component = neighbours[0]
         else:
+            Logger.log_to_selected(
+                f"Failed to convert {tline.name} because fewer than two connections were found"
+            )
             return False
         # Get string mapped to the type of the other component
         switch_et = self._create_pandapower_switch_et(switch_other_component)

--- a/epowcore/power_factory/from_gdf/components/external_grid.py
+++ b/epowcore/power_factory/from_gdf/components/external_grid.py
@@ -11,26 +11,32 @@ def create_external_grid(self, external_grid: ExternalGrid) -> bool:
     :return: Return true if the conversion suceeded, false if it didn't.
     :rtype: bool
     """
-    success = True
 
-    # Create new switch inside of grid
-    pf_external_grid = self.pf_grid.CreateObject("ElmXnet", external_grid.name)
+    connection = self.core_model.get_neighbors(
+        component=external_grid, follow_links=True
+    )
 
-    connection = self.core_model.get_neighbors(component=external_grid, follow_links=True)[0]
-    if connection  is None:
+    if not connection:
         Logger.log_to_selected(
             f"Connection not found inside of the gdf for external grid {external_grid.name}"
         )
-        success = False
+        return False
 
     # Get powerfactory connections
-    pf_connection = get_pf_grid_component(self, component_name=connection.name)
+    pf_connection = get_pf_grid_component(
+        self, component_name=connection[0].name
+    )
 
     if pf_connection is None:
         Logger.log_to_selected(
             f"Connection not found inside of powerfactory for external grid {external_grid.name}"
         )
-        success = False
+        return False
+
+    # Create external grid only after all checks succeeded
+    pf_external_grid = self.pf_grid.CreateObject(
+        "ElmXnet", external_grid.name
+    )
 
     # Set connections
     pf_external_grid.SetAttribute("bus1", add_cubicle_to_bus(pf_connection))
@@ -40,9 +46,9 @@ def create_external_grid(self, external_grid: ExternalGrid) -> bool:
     pf_external_grid.qgini = external_grid.q
     pf_external_grid.cQ_min = external_grid.q_min
     pf_external_grid.cQ_max = external_grid.q_max
-    pf_external_grid.bustp =  external_grid.bus_type.value
+    pf_external_grid.bustp = external_grid.bus_type.value
     if external_grid.coords is not None:
         pf_external_grid.GPSlon = external_grid.coords[1]
         pf_external_grid.GPSlat = external_grid.coords[0]
 
-    return success
+    return True

--- a/epowcore/power_factory/from_gdf/components/generators.py
+++ b/epowcore/power_factory/from_gdf/components/generators.py
@@ -152,33 +152,32 @@ def create_static_generator(self, gen: StaticGenerator) -> bool:
     :return: Return true if the conversion suceeded, false if it didn't.
     :rtype: bool
     """
-    success = True
-
-    # Create generator inside of network
-    pf_gen = self.pf_grid.CreateObject("ElmGenstat", gen.name)
 
     # Get bus connected to the generator
-    gdf_gen_bus = get_connected_bus(graph=self.core_model.graph, node=gen, max_depth=1)
+    gdf_gen_bus = get_connected_bus(
+        graph=self.core_model.graph, node=gen, max_depth=1
+    )
 
     if gdf_gen_bus is None:
         Logger.log_to_selected(
             f"There was no generator bus found inside of the core_model network for the static generator {gen.name}"
         )
-        success = False
-    else:
-        if gdf_gen_bus.lf_bus_type == "SLACK":
-            pf_gen.SetAttribute("ip_ctrl", 1)
+        return False
 
     pf_gen_bus = get_pf_grid_component(self, component_name=gdf_gen_bus.name)
     if pf_gen_bus is None:
         Logger.log_to_selected(
             f"There was no generator bus found inside of the powerfactory network for the static generator {gen.name}"
         )
-        success = False
+        return False
 
-    # If the bus was found set connection attribute
-    if success:
-        pf_gen.SetAttribute("bus1", add_cubicle_to_bus(pf_gen_bus))
+    # Create generator only after all checks succeeded
+    pf_gen = self.pf_grid.CreateObject("ElmGenstat", gen.name)
+
+    if gdf_gen_bus.lf_bus_type == "SLACK":
+        pf_gen.SetAttribute("ip_ctrl", 1)
+
+    pf_gen.SetAttribute("bus1", add_cubicle_to_bus(pf_gen_bus))
 
     # Set attributes of the generator itself
     pf_gen.SetAttribute("sgn", gen.rated_apparent_power)
@@ -194,4 +193,4 @@ def create_static_generator(self, gen: StaticGenerator) -> bool:
         pf_gen.GPSlon = gen.coords[0]
         pf_gen.GPSlat = gen.coords[1]
 
-    return success
+    return True

--- a/epowcore/power_factory/from_gdf/components/line.py
+++ b/epowcore/power_factory/from_gdf/components/line.py
@@ -11,28 +11,32 @@ def create_line(self, tline: TLine) -> bool:
     :return: Return true if the conversion suceeded, false if it didn't.
     :rtype: bool
     """
-    success = True
 
-    # Create new line inside of grid
-    pf_line = self.pf_grid.CreateObject("ElmLne", tline.name)
+    from_bus = self.core_model.get_neighbors(
+        component=tline, follow_links=True, connector="A"
+    )
+    to_bus = self.core_model.get_neighbors(
+        component=tline, follow_links=True, connector="B"
+    )
 
-    from_bus = self.core_model.get_neighbors(component=tline, follow_links=True, connector="A")[0]
-    to_bus = self.core_model.get_neighbors(component=tline, follow_links=True, connector="B")[0]
-    if from_bus is None or to_bus is None:
+    if not from_bus or not to_bus:
         Logger.log_to_selected(
             f"At least one bus not found inside of the gdf for tline {tline.name}"
         )
-        success = False
+        return False
 
     # Get powerfactory buses
-    pf_from_bus = get_pf_grid_component(self, component_name=from_bus.name)
-    pf_to_bus = get_pf_grid_component(self, component_name=to_bus.name)
+    pf_from_bus = get_pf_grid_component(self, component_name=from_bus[0].name)
+    pf_to_bus = get_pf_grid_component(self, component_name=to_bus[0].name)
 
     if pf_from_bus is None or pf_to_bus is None:
         Logger.log_to_selected(
             f"At least one bus not found inside of powerfactory for tline {tline.name}"
         )
-        success = False
+        return False
+
+    # Create new line inside of grid only after all checks succeeded
+    pf_line = self.pf_grid.CreateObject("ElmLne", tline.name)
 
     # Set connections
     pf_line.SetAttribute("bus1", add_cubicle_to_bus(pf_from_bus))
@@ -53,9 +57,9 @@ def create_line(self, tline: TLine) -> bool:
     pf_line_type.SetAttribute("xline", tline.x1)
     pf_line_type.SetAttribute("bline", tline.b1)
     # Standard type cables for low voltage grids have a rating of 1kV
-    rating_from_bus = pf_from_bus.GetAttribute("uknom") #kV
+    rating_from_bus = pf_from_bus.GetAttribute("uknom")  # kV
     pf_line_type.SetAttribute("uline", rating_from_bus)
-    pf_line_type.SetAttribute("sline", tline.rating / (rating_from_bus))
+    pf_line_type.SetAttribute("sline", tline.rating / rating_from_bus)
     pf_line_type.SetAttribute("rline0", zero_sequence_transform(tline.r0))
     pf_line_type.SetAttribute("xline0", zero_sequence_transform(tline.x0))
     pf_line_type.SetAttribute("bline0", zero_sequence_transform(tline.b0))
@@ -64,9 +68,9 @@ def create_line(self, tline: TLine) -> bool:
     pf_line.SetAttribute("nlnum", tline.parallel_lines)
     pf_line.SetAttribute("dline", tline.length)
     pf_line.SetAttribute("loc_name", tline.name)
-    if  tline.coords is not None:
-        pf_line.GPScoords = [[coords[0],coords[1]] for coords in tline.coords]
+    if tline.coords is not None:
+        pf_line.GPScoords = [[coords[0], coords[1]] for coords in tline.coords]
     # Set line type attribut to the newly crated line type
     pf_line.SetAttribute("typ_id", pf_line_type)
 
-    return success
+    return True

--- a/epowcore/power_factory/from_gdf/components/load.py
+++ b/epowcore/power_factory/from_gdf/components/load.py
@@ -12,30 +12,34 @@ def create_load(self, load: Load) -> bool:
     :return: Return true if the conversion suceeded, false if it didn't.
     :rtype: bool
     """
-    success = True
-
-    # Create load inside of network
-    pf_load = self.pf_grid.CreateObject("ElmLod")
 
     # Get connected bus
     # Maybe change this so the load gets converted without a connected bus if it is not found?
-    gdf_load_bus = get_connected_bus(graph=self.core_model.graph, node=load, max_depth=1)
+    gdf_load_bus = get_connected_bus(
+        graph=self.core_model.graph, node=load, max_depth=1
+    )
+
     # Check if connected bus exists
     if gdf_load_bus is None:
         Logger.log_to_selected(
             f"There was no load bus found inside of the core_model network for the load {load.name}"
         )
-        success = False
-    else:
-        # Find the power factory bus with the same name
-        pf_load_bus = get_pf_grid_component(self, component_name=gdf_load_bus.name)
-        if pf_load_bus is None:
-            Logger.log_to_selected(
-                f"Something went wrong with the conversion of the load {load.name}, because its bus was found inside of the gdf network but not in the powerfactory network"
-            )
-            success = False
-        else:
-            pf_load.SetAttribute("bus1", add_cubicle_to_bus(pf_load_bus))
+        return False
+
+    # Find the power factory bus with the same name
+    pf_load_bus = get_pf_grid_component(
+        self, component_name=gdf_load_bus.name
+    )
+
+    if pf_load_bus is None:
+        Logger.log_to_selected(
+            f"Something went wrong with the conversion of the load {load.name}, because its bus was found inside of the gdf network but not in the powerfactory network"
+        )
+        return False
+
+    # Create load only after all checks succeeded
+    pf_load = self.pf_grid.CreateObject("ElmLod")
+    pf_load.SetAttribute("bus1", add_cubicle_to_bus(pf_load_bus))
 
     # Set attributes for newly created load
     pf_load.SetAttribute("loc_name", load.name)
@@ -47,4 +51,4 @@ def create_load(self, load: Load) -> bool:
         pf_load.GPSlon = load.coords[1]
         pf_load.GPSlat = load.coords[0]
 
-    return success
+    return True

--- a/epowcore/power_factory/from_gdf/components/pv_system.py
+++ b/epowcore/power_factory/from_gdf/components/pv_system.py
@@ -10,26 +10,30 @@ def create_pv_system(self, pv_system: PVSystem) -> bool:
     :return: Return true if the conversion suceeded, false if it didn't.
     :rtype: bool
     """
-    success = True
 
-    # Create new switch1 inside of grid
-    pf_pv_system = self.pf_grid.CreateObject("ElmPvsys", pv_system.name)
+    from_bus = self.core_model.get_neighbors(
+        component=pv_system, follow_links=True
+    )
 
-    from_bus= self.core_model.get_neighbors(component=pv_system, follow_links=True)[0]
-    if from_bus is None:
+    if not from_bus:
         Logger.log_to_selected(
             f"Connection not found inside of the gdf for pv_system {pv_system.name}"
         )
-        success = False
+        return False
 
     # Get powerfactory connections
-    pf_from_bus = get_pf_grid_component(self, component_name=from_bus.name)
+    pf_from_bus = get_pf_grid_component(
+        self, component_name=from_bus[0].name
+    )
 
     if pf_from_bus is None:
         Logger.log_to_selected(
             f"Connection not found inside of powerfactory for pv_system {pv_system.name}"
         )
-        success = False
+        return False
+
+    # Create pv system only after all checks succeeded
+    pf_pv_system = self.pf_grid.CreateObject("ElmPvsys", pv_system.name)
 
     # Set connections
     pf_pv_system.SetAttribute("bus1", add_cubicle_to_bus(pf_from_bus))
@@ -37,11 +41,12 @@ def create_pv_system(self, pv_system: PVSystem) -> bool:
     # PV type in PowerFactory has no values that can be set from the GDF model, therefore a standard type in the PowerFactory Library is used
     # Create new type
     pf_pv_system.SetAttribute("typ_id", self.standard_pv_type)
-    pf_pv_system.SetAttribute("sgn", pv_system.rated_power/1000)
+    pf_pv_system.SetAttribute("sgn", pv_system.rated_power / 1000)
     if pv_system.coords is not None:
         pf_pv_system.GPSlon = pv_system.coords[1]
         pf_pv_system.GPSlat = pv_system.coords[0]
+
     # Model solar calculation
     pf_pv_system.SetAttribute("mode_pgi", 1)
 
-    return success
+    return True

--- a/epowcore/power_factory/from_gdf/components/shunt.py
+++ b/epowcore/power_factory/from_gdf/components/shunt.py
@@ -12,31 +12,34 @@ def create_shunt(self, shunt: Shunt) -> bool:
     :return: Return true if the conversion succeded, false if it didn't.
     :rtype: bool
     """
-    success = True
-
-    # Create shunt inside the pf network
-    pf_shunt = self.pf_grid.CreateObject("ElmShnt")
 
     # Get connected bus
-    gdf_shunt_bus = get_connected_bus(graph=self.core_model.graph, node=shunt, max_depth=1)
+    gdf_shunt_bus = get_connected_bus(
+        graph=self.core_model.graph, node=shunt, max_depth=1
+    )
+
     # Check if the connected bus exists
     if gdf_shunt_bus is None:
         Logger.log_to_selected(
             f"There was no shunt bus found inside of the core_model network for the load {shunt.name}"
         )
-        success = False
-    else:
-        # Find the power factory bus with the same name
-        pf_shunt_bus = get_pf_grid_component(self, component_name=gdf_shunt_bus.name)
-        if pf_shunt_bus is None:
-            Logger.log_to_selected(
-                f"Something went wrong with the conversion of the shunt {shunt.name}, because its bus was found inside of the gdf network but not in the powerfactory network"
-            )
-            success = False
-        else:
-            pf_shunt.SetAttribute("bus1", add_cubicle_to_bus(pf_shunt_bus))
+        return False
 
-        
+    # Find the power factory bus with the same name
+    pf_shunt_bus = get_pf_grid_component(
+        self, component_name=gdf_shunt_bus.name
+    )
+
+    if pf_shunt_bus is None:
+        Logger.log_to_selected(
+            f"Something went wrong with the conversion of the shunt {shunt.name}, because its bus was found inside of the gdf network but not in the powerfactory network"
+        )
+        return False
+
+    # Create shunt only after all checks succeeded
+    pf_shunt = self.pf_grid.CreateObject("ElmShnt")
+    pf_shunt.SetAttribute("bus1", add_cubicle_to_bus(pf_shunt_bus))
+
     # Set attributes for newly created shunt
     pf_shunt.SetAttribute("loc_name", shunt.name)
     pf_shunt.SetAttribute("e:Qact", shunt.q)
@@ -44,5 +47,4 @@ def create_shunt(self, shunt: Shunt) -> bool:
         pf_shunt.GPSlon = shunt.coords[1]
         pf_shunt.GPSlat = shunt.coords[0]
 
-
-    return success
+    return True

--- a/epowcore/power_factory/from_gdf/components/transformers.py
+++ b/epowcore/power_factory/from_gdf/components/transformers.py
@@ -18,15 +18,11 @@ def create_three_wdg_trafo(self, trafo: ThreeWindingTransformer) -> bool:
     :return: Return true if the conversion suceeded, false if it didn't.
     :rtype: bool
     """
-    success = True
-
-    # Create new trafo inside of grid
-    pf_trafo = self.pf_grid.CreateObject("ElmTr3", trafo.name)
 
     # Get the bus connected to the transformer on the high voltage side
     high_voltage_bus = self.core_model.get_neighbors(
         component=trafo, follow_links=True, connector="HV"
-    )[0]
+    )
     # Get the bus connected to the transformer on the middle voltage side
     middle_voltage_bus = self.core_model.get_neighbors(
         component=trafo, follow_links=True, connector="MV"
@@ -34,22 +30,36 @@ def create_three_wdg_trafo(self, trafo: ThreeWindingTransformer) -> bool:
     # Get the bus connected to the transformer on the low voltage side
     low_voltage_bus = self.core_model.get_neighbors(
         component=trafo, follow_links=True, connector="LV"
-    )[0]
+    )
+
     # If either bus wasnt found the function failed
-    if high_voltage_bus is None or low_voltage_bus is None or middle_voltage_bus is None:
-        Logger.log_to_selected(f"Failled to convert three winding transformer {trafo.name}")
-        success = False
+    if not high_voltage_bus or not middle_voltage_bus or not low_voltage_bus:
+        Logger.log_to_selected(
+            f"Failled to convert three winding transformer {trafo.name}"
+        )
+        return False
+
     # Get powerfactory buses
-    pf_hv_bus = get_pf_grid_component(self, component_name=high_voltage_bus.name)
-    pf_mv_bus = get_pf_grid_component(self, component_name=middle_voltage_bus.name)
-    pf_lv_bus = get_pf_grid_component(self, component_name=low_voltage_bus.name)
+    pf_hv_bus = get_pf_grid_component(
+        self, component_name=high_voltage_bus[0].name
+    )
+    pf_mv_bus = get_pf_grid_component(
+        self, component_name=middle_voltage_bus[0].name
+    )
+    pf_lv_bus = get_pf_grid_component(
+        self, component_name=low_voltage_bus[0].name
+    )
+
     # Fails if no powerfactory buses are found
     if pf_hv_bus is None or pf_mv_bus is None or pf_lv_bus is None:
         Logger.log_to_selected(
             f"Three winding transformer {trafo.name} could not be converted because atleast one bus wasn't found."
         )
-        success = False
-    
+        return False
+
+    # Create new trafo inside of grid only after all checks succeeded
+    pf_trafo = self.pf_grid.CreateObject("ElmTr3", trafo.name)
+
     # Set connections
     pf_trafo.SetAttribute("bushv", add_cubicle_to_bus(pf_hv_bus))
     pf_trafo.SetAttribute("busmv", add_cubicle_to_bus(pf_mv_bus))
@@ -77,9 +87,15 @@ def create_three_wdg_trafo(self, trafo: ThreeWindingTransformer) -> bool:
     pf_trafo_type.SetAttribute("r1_lh", trafo.r1pu_l)
     pf_trafo_type.SetAttribute("pfe_kw", trafo.pfe_kw)
     pf_trafo_type.SetAttribute("curm3", trafo.no_load_current)
-    pf_trafo_type.SetAttribute("tr3cn_h", REVERSE_WINDING_CONFIG_MAPPING[trafo.connection_type_hv])
-    pf_trafo_type.SetAttribute("tr3cn_m", REVERSE_WINDING_CONFIG_MAPPING[trafo.connection_type_mv])
-    pf_trafo_type.SetAttribute("tr3cn_l", REVERSE_WINDING_CONFIG_MAPPING[trafo.connection_type_lv])
+    pf_trafo_type.SetAttribute(
+        "tr3cn_h", REVERSE_WINDING_CONFIG_MAPPING[trafo.connection_type_hv]
+    )
+    pf_trafo_type.SetAttribute(
+        "tr3cn_m", REVERSE_WINDING_CONFIG_MAPPING[trafo.connection_type_mv]
+    )
+    pf_trafo_type.SetAttribute(
+        "tr3cn_l", REVERSE_WINDING_CONFIG_MAPPING[trafo.connection_type_lv]
+    )
     pf_trafo_type.SetAttribute("nt3ag_h", trafo.phase_shift_30_hv)
     pf_trafo_type.SetAttribute("nt3ag_m", trafo.phase_shift_30_mv)
     pf_trafo_type.SetAttribute("nt3ag_l", trafo.phase_shift_30_lv)
@@ -88,12 +104,11 @@ def create_three_wdg_trafo(self, trafo: ThreeWindingTransformer) -> bool:
 
     # Set trafo type attribute to the newly created trafo type
     pf_trafo.SetAttribute("typ_id", pf_trafo_type)
-    if  trafo.coords is not None:
+    if trafo.coords is not None:
         pf_trafo.GPSlon = trafo.coords[1]
         pf_trafo.GPSlat = trafo.coords[0]
 
-
-    return success
+    return True
 
 
 def create_two_wdg_trafo(self, trafo: TwoWindingTransformer) -> bool:

--- a/tests/pandapower/pandapower_line_parameters_test.py
+++ b/tests/pandapower/pandapower_line_parameters_test.py
@@ -71,3 +71,23 @@ def test_line_export_rejects_zero_nominal_voltage() -> None:
             name="invalid_voltage_test",
             log_path=None,
         )
+
+def test_line_with_missing_connection_is_skipped() -> None:
+    creator = GdfTestComponentCreator(base_frequency=50.0)
+
+    bus_a = creator.create_bus(name="Bus A")
+    line = creator.create_tline(name="Incomplete Line")
+
+    creator.core_model.add_connection(line, bus_a, "A")
+
+    network = (
+        PandapowerConverter()
+        .from_gdf(
+            core_model=creator.core_model,
+            name="missing_connection_test",
+            log_path=None,
+        )
+        .network
+    )
+
+    assert "Incomplete Line" not in network.line["name"].values

--- a/tests/power_factory/pf_converter_test.py
+++ b/tests/power_factory/pf_converter_test.py
@@ -1,5 +1,11 @@
+
 import unittest
+from unittest.mock import MagicMock
+
+from helpers.gdf_component_creator import GdfTestComponentCreator
+
 from epowcore.gdf.transformers.two_winding_transformer import TwoWindingTransformer
+from epowcore.power_factory.from_gdf.components.line import create_line
 from epowcore.power_factory.power_factory_converter import PFModel, PowerFactoryConverter
 
 
@@ -25,6 +31,23 @@ class PFConverterTest(unittest.TestCase):
                 for x in core_model.graph.edges.data()
             )
         )
+
+    def test_line_with_missing_connection_is_skipped(self) -> None:
+        creator = GdfTestComponentCreator(base_frequency=50.0)
+
+        bus_a = creator.create_bus(name="Bus A")
+        line = creator.create_tline(name="Incomplete Line")
+
+        creator.core_model.add_connection(line, bus_a, "A")
+
+        exporter = MagicMock()
+        exporter.core_model = creator.core_model
+        exporter.pf_grid = MagicMock()
+
+        result = create_line(exporter, line)
+
+        self.assertFalse(result)
+        exporter.pf_grid.CreateObject.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- skip GDF components when required connections are missing
- create PowerFactory objects only after connection validation succeeds
- add missing logging for pandapower connection failures
- add regression tests for incomplete line connections

## Tests
- core: 52 passed, 8 skipped
- pandapower line tests: 3 passed
- PowerFactory missing-connection regression: 1 passed

## Notes
- the existing PowerFactory Minimal integration test still depends on the local Minimal project being available
- two IEEE39 pandapower plausibility tests show reactive-power deviations unrelated to this connection-handling change