### PR TITLE
Inherit Site geodata for PowerFactory components

### DIFF
--- a/epowcore/power_factory/utils.py
+++ b/epowcore/power_factory/utils.py
@@ -4,17 +4,36 @@ from typing import Any
 
 def get_coords(obj: Any) -> tuple[float, float] | list[tuple[float, float]] | None:
     """Try to get the coordinates of a given PowerFactory object."""
-    if not (hasattr(obj, "GPSlat") and hasattr(obj, "GPSlon")) and not hasattr(obj, "GPScoords"):
+
+    if not (hasattr(obj, "GPSlat") and hasattr(obj, "GPSlon")) and not hasattr(
+        obj, "GPScoords"
+    ):
         return None
+
     if hasattr(obj, "GPScoords"):
         lat = [x[0] for x in obj.GPScoords if len(x) > 1]
         lon = [x[1] for x in obj.GPScoords if len(x) > 1]
+
         if len(lat) == 0 or len(lon) == 0:
             return None
+
         return list(zip(lat, lon))
-    if obj.GPSlat == 0.0 and obj.GPSlon == 0.0:
+
+    if obj.GPSlat != 0.0 or obj.GPSlon != 0.0:
+        return (obj.GPSlat, obj.GPSlon)
+
+    parent = obj.GetParent()
+
+    if parent is None or parent.GetClassName() != "ElmSite":
         return None
-    return (obj.GPSlat, obj.GPSlon)
+
+    if not (hasattr(parent, "GPSlat") and hasattr(parent, "GPSlon")):
+        return None
+
+    if parent.GPSlat == 0.0 and parent.GPSlon == 0.0:
+        return None
+
+    return (parent.GPSlat, parent.GPSlon)
 
 
 def get_ctrl_param(ctrl_obj: Any, param: str | list[str]) -> Any:

--- a/tests/power_factory/utils_test.py
+++ b/tests/power_factory/utils_test.py
@@ -1,0 +1,74 @@
+from epowcore.power_factory.utils import get_coords
+
+
+class FakePFObject:
+    def __init__(
+        self,
+        class_name: str,
+        gps_lat: float = 0.0,
+        gps_lon: float = 0.0,
+        parent=None,
+    ) -> None:
+        self._class_name = class_name
+        self.GPSlat = gps_lat
+        self.GPSlon = gps_lon
+        self._parent = parent
+
+    def GetClassName(self) -> str:
+        return self._class_name
+
+    def GetParent(self):
+        return self._parent
+
+
+def test_get_coords_keeps_component_coordinates() -> None:
+    component = FakePFObject(
+        class_name="ElmLod",
+        gps_lat=49.01,
+        gps_lon=8.41,
+    )
+
+    assert get_coords(component) == (49.01, 8.41)
+
+
+def test_get_coords_inherits_coordinates_from_site() -> None:
+    site = FakePFObject(
+        class_name="ElmSite",
+        gps_lat=49.02,
+        gps_lon=8.42,
+    )
+
+    component = FakePFObject(
+        class_name="ElmLod",
+        parent=site,
+    )
+
+    assert get_coords(component) == (49.02, 8.42)
+
+
+def test_get_coords_does_not_inherit_from_non_site_parent() -> None:
+    parent = FakePFObject(
+        class_name="ElmNet",
+        gps_lat=49.03,
+        gps_lon=8.43,
+    )
+
+    component = FakePFObject(
+        class_name="ElmLod",
+        parent=parent,
+    )
+
+    assert get_coords(component) is None
+
+
+def test_get_coords_returns_none_if_site_has_default_coordinates() -> None:
+    site = FakePFObject(
+        class_name="ElmSite",
+    )
+
+    component = FakePFObject(
+        class_name="ElmLod",
+        parent=site,
+    )
+
+    assert get_coords(component) is None


### PR DESCRIPTION
Summary

- Inherit ElmSite coordinates when contained components have default (0, 0) coordinates.
- Preserve existing component coordinates when already defined.
- Leave components outside ElmSite unchanged.
- Add regression tests for the inheritance behavior.

Tests

- tests/power_factory/utils_test.py: 4 passed
- tests/core: 52 passed, 8 skipped
- Verified with PowerFactory 2023 SP2 using an ElmSite containing an ElmTerm child.