### PR TITLE
feat: add pandapower to GDF importer and test coverage

### DIFF
--- a/config/pandapower.yml
+++ b/config/pandapower.yml
@@ -2,18 +2,35 @@ TLine:
   zero_sequence_factor: 3
   temperature_degree_celsius: 80
   alpha: 0.004
+
 TwoWindingTransformer:
   si0_hv_partial: 0.9
   mag0_rx: 0
   mag0_percent: 100
+
 ThreeWindingTransformer:
   vk_percent: 10.4
   vkr_hv_percent: 0.28
   vkr_mv_percent: 0.32
   vkr_lv_percent: 0.35
+
 Load:
   type: "wye"
   const_z_percent: 0  # pandapower convert says 100 but loadflows dont converge then
   const_i_percent: 0
+
 Switch:
-  in_ka: 0.27 # in MVA 
+  in_ka: 0.27 # in MVA
+
+SynchronousMachine:
+  inertia_constant: 4.475
+  zero_sequence_resistance: 0.0
+  zero_sequence_reactance: 0.1
+  stator_leakage_reactance: 0.2432
+  stator_resistance: 0.0
+  synchronous_reactance_x: 1.996
+  transient_reactance_x: 0.4248
+  subtransient_reactance_x: 0.36
+  synchronous_reactance_q: 1.896
+  transient_reactance_q: 0.7008
+  subtransient_reactance_q: 0.36

--- a/epowcore/pandapower/pandapower_converter.py
+++ b/epowcore/pandapower/pandapower_converter.py
@@ -9,6 +9,7 @@ from epowcore.pandapower.from_gdf.pandapower_export import (
     export_pandapower,
 )
 from epowcore.pandapower.pandapower_model import PandapowerModel
+from epowcore.pandapower.to_gdf.pandapower_extractor import PandapowerExtractor
 from epowcore.plausibility.pandapower_checker import (
     PandapowerPlausibilityChecker,
 )
@@ -79,5 +80,6 @@ class PandapowerConverter(ConverterBase[PandapowerModel]):
             filename=filepath,
         )
 
-    def _import(self, model):
-        return model
+    def _import(self, model: PandapowerModel) -> CoreModel:
+        extractor = PandapowerExtractor(model.network)
+        return extractor.get_core_model()

--- a/epowcore/pandapower/to_gdf/pandapower_extractor.py
+++ b/epowcore/pandapower/to_gdf/pandapower_extractor.py
@@ -1,0 +1,606 @@
+import pandas as pd
+import pandapower
+import math
+from epowcore.gdf.bus import Bus, BusType, LFBusType
+from epowcore.gdf.core_model import CoreModel
+from epowcore.gdf.external_grid import ExternalGrid, ExternalGridType
+from epowcore.gdf.generators.static_generator import StaticGenerator
+from epowcore.gdf.generators.synchronous_machine import SynchronousMachine
+from epowcore.gdf.load import Load
+from epowcore.generic.configuration import Configuration
+from epowcore.generic.constants import Platform
+from epowcore.generic.logger import Logger
+from epowcore.gdf.tline import TLine
+from epowcore.gdf.transformers.two_winding_transformer import TwoWindingTransformer
+from epowcore.gdf.switch import Switch
+
+
+
+class PandapowerExtractor:
+    """Extract a pandapower network into a GDF CoreModel."""
+
+    def __init__(self, network: pandapower.pandapowerNet) -> None:
+        self.network = network
+
+        self.core_model = CoreModel(
+            base_frequency=network.f_hz,
+            base_mva=network.sn_mva,
+        )
+
+        self.uid = 0
+        self.bus_map: dict[int, Bus] = {}
+        self.line_map: dict[int, TLine] = {}
+        self.trafo_map: dict[int, TwoWindingTransformer] = {}
+
+        self._extract_buses()
+        self._extract_loads()
+        self._extract_external_grids()
+        self._extract_static_generators()
+        self._extract_synchronous_machines()
+        self._extract_lines()
+        self._extract_two_winding_transformers()
+        self._extract_switches()
+
+
+    def _get_default(
+        self,
+        component: str,
+        attr: str,
+        name: str,
+    ) -> float:
+        value = Configuration().get_default(
+            component,
+            attr,
+            Platform.PANDAPOWER,
+        )
+
+        Logger.log_to_selected(
+            f"Using default for {component} '{name}': {attr} = {value}"
+        )
+
+        if value is None:
+            raise ValueError(
+                f"No pandapower default configured for {component}.{attr}"
+            )
+
+        return float(value)
+
+    def _extract_buses(self) -> None:
+        slack_bus_indices = set(
+            self.network.ext_grid["bus"].astype(int).tolist()
+        )
+
+        for index, row in self.network.bus.iterrows():
+            name = row["name"]
+            if name is None:
+                name = f"Bus {index}"
+
+            bus_type = BusType.BUSBAR
+            if row["type"] == "n":
+                bus_type = BusType.JUNCTION
+
+            lf_bus_type = (
+                LFBusType.SL
+                if int(index) in slack_bus_indices
+                else LFBusType.PQ
+            )
+
+            bus = Bus(
+                uid=self.uid,
+                name=str(name),
+                nominal_voltage=float(row["vn_kv"]),
+                lf_bus_type=lf_bus_type,
+                bus_type=bus_type,
+            )
+
+            self.core_model.add_component(bus)
+            self.bus_map[int(index)] = bus
+            self.uid += 1
+
+    def _extract_loads(self) -> None:
+        for index, row in self.network.load.iterrows():
+            bus_index = int(row["bus"])
+
+            if bus_index not in self.bus_map:
+                continue
+
+            name = row["name"]
+            if name is None:
+                name = f"Load {index}"
+
+            load = Load(
+                uid=self.uid,
+                name=str(name),
+                active_power=float(row["p_mw"]),
+                reactive_power=float(row["q_mvar"]),
+            )
+
+            self.core_model.add_component(load)
+            self.core_model.add_connection(
+                load,
+                self.bus_map[bus_index],
+            )
+
+            self.uid += 1
+
+    def _extract_external_grids(self) -> None:
+        for index, row in self.network.ext_grid.iterrows():
+            bus_index = int(row["bus"])
+
+            if bus_index not in self.bus_map:
+                continue
+
+            name = row["name"]
+            if name is None:
+                name = f"External Grid {index}"
+
+            external_grid = ExternalGrid(
+                uid=self.uid,
+                name=str(name),
+                u_setp=float(row["vm_pu"]),
+                p=0.0,
+                q=0.0,
+                p_min=(
+                    float(row["min_p_mw"])
+                    if "min_p_mw" in row
+                    and not pd.isna(row["min_p_mw"])
+                    else None
+                ),
+                p_max=(
+                    float(row["max_p_mw"])
+                    if "max_p_mw" in row
+                    and not pd.isna(row["max_p_mw"])
+                    else None
+                ),
+                q_min=(
+                    float(row["min_q_mvar"])
+                    if "min_q_mvar" in row
+                    and not pd.isna(row["min_q_mvar"])
+                    else 0.0
+                ),
+                q_max=(
+                    float(row["max_q_mvar"])
+                    if "max_q_mvar" in row
+                    and not pd.isna(row["max_q_mvar"])
+                    else 0.0
+                ),
+                bus_type=ExternalGridType.SL,
+            )
+
+            self.core_model.add_component(external_grid)
+
+            bus = self.bus_map[bus_index]
+
+            self.core_model.add_connection(
+                external_grid,
+                bus,
+            )
+
+            self.uid += 1
+
+    def _extract_static_generators(self) -> None:
+        for index, row in self.network.sgen.iterrows():
+            bus_index = int(row["bus"])
+
+            if bus_index not in self.bus_map:
+                continue
+
+            name = row["name"]
+            if name is None:
+                name = f"Static Generator {index}"
+
+            p_mw = float(row["p_mw"])
+            q_mvar = float(row["q_mvar"])
+
+            static_generator = StaticGenerator(
+                uid=self.uid,
+                name=str(name),
+                rated_apparent_power=(
+                    float(row["sn_mva"])
+                    if "sn_mva" in row
+                    and not pd.isna(row["sn_mva"])
+                    else 0.0
+                ),
+                rated_active_power=p_mw,
+                active_power=p_mw,
+                reactive_power=q_mvar,
+                voltage_set_point=1.0,
+                p_min=(
+                    float(row["min_p_mw"])
+                    if "min_p_mw" in row
+                    and not pd.isna(row["min_p_mw"])
+                    else 0.0
+                ),
+                p_max=(
+                    float(row["max_p_mw"])
+                    if "max_p_mw" in row
+                    and not pd.isna(row["max_p_mw"])
+                    else p_mw
+                ),
+                q_min=(
+                    float(row["min_q_mvar"])
+                    if "min_q_mvar" in row
+                    and not pd.isna(row["min_q_mvar"])
+                    else 0.0
+                ),
+                q_max=(
+                    float(row["max_q_mvar"])
+                    if "max_q_mvar" in row
+                    and not pd.isna(row["max_q_mvar"])
+                    else q_mvar
+                ),
+            )
+
+            self.core_model.add_component(static_generator)
+            self.core_model.add_connection(
+                static_generator,
+                self.bus_map[bus_index],
+            )
+
+            self.uid += 1
+
+    def _extract_synchronous_machines(self) -> None:
+        for index, row in self.network.gen.iterrows():
+            bus_index = int(row["bus"])
+
+            if bus_index not in self.bus_map:
+                continue
+
+            name = row["name"]
+            if name is None:
+                name = f"Synchronous Machine {index}"
+
+            bus = self.bus_map[bus_index]
+            p_mw = float(row["p_mw"])
+
+            rated_apparent_power = (
+                float(row["sn_mva"])
+                if "sn_mva" in row
+                and not pd.isna(row["sn_mva"])
+                else abs(p_mw)
+            )
+
+            p_min = (
+                float(row["min_p_mw"])
+                if "min_p_mw" in row
+                and not pd.isna(row["min_p_mw"])
+                else 0.0
+            )
+
+            p_max = (
+                float(row["max_p_mw"])
+                if "max_p_mw" in row
+                and not pd.isna(row["max_p_mw"])
+                else p_mw
+            )
+
+            q_min = (
+                float(row["min_q_mvar"])
+                if "min_q_mvar" in row
+                and not pd.isna(row["min_q_mvar"])
+                else 0.0
+            )
+
+            q_max = (
+                float(row["max_q_mvar"])
+                if "max_q_mvar" in row
+                and not pd.isna(row["max_q_mvar"])
+                else 0.0
+            )
+
+            synchronous_machine = SynchronousMachine(
+                uid=self.uid,
+                name=str(name),
+                rated_apparent_power=rated_apparent_power,
+                rated_active_power=p_mw,
+                rated_voltage=bus.nominal_voltage,
+                active_power=p_mw,
+                reactive_power=0.0,
+                voltage_set_point=float(row["vm_pu"]),
+                inertia_constant=self._get_default(
+                    "SynchronousMachine",
+                    "inertia_constant",
+                    str(name),
+                ),
+                zero_sequence_resistance=self._get_default(
+                    "SynchronousMachine",
+                    "zero_sequence_resistance",
+                    str(name),
+                ),
+                zero_sequence_reactance=self._get_default(
+                    "SynchronousMachine",
+                    "zero_sequence_reactance",
+                    str(name),
+                ),
+                stator_leakage_reactance=self._get_default(
+                    "SynchronousMachine",
+                    "stator_leakage_reactance",
+                    str(name),
+                ),
+                stator_resistance=self._get_default(
+                    "SynchronousMachine",
+                    "stator_resistance",
+                    str(name),
+                ),
+                synchronous_reactance_x=self._get_default(
+                    "SynchronousMachine",
+                    "synchronous_reactance_x",
+                    str(name),
+                ),
+                transient_reactance_x=self._get_default(
+                    "SynchronousMachine",
+                    "transient_reactance_x",
+                    str(name),
+                ),
+                subtransient_reactance_x=self._get_default(
+                    "SynchronousMachine",
+                    "subtransient_reactance_x",
+                    str(name),
+                ),
+                synchronous_reactance_q=self._get_default(
+                    "SynchronousMachine",
+                    "synchronous_reactance_q",
+                    str(name),
+                ),
+                transient_reactance_q=self._get_default(
+                    "SynchronousMachine",
+                    "transient_reactance_q",
+                    str(name),
+                ),
+                subtransient_reactance_q=self._get_default(
+                    "SynchronousMachine",
+                    "subtransient_reactance_q",
+                    str(name),
+                ),
+                p_min=p_min,
+                p_max=p_max,
+                q_min=q_min,
+                q_max=q_max,
+                pc1=p_min,
+                pc2=p_max,
+                qc1_min=q_min,
+                qc1_max=q_max,
+                qc2_min=q_min,
+                qc2_max=q_max,
+            )
+
+            self.core_model.add_component(synchronous_machine)
+            self.core_model.add_connection(
+                synchronous_machine,
+                bus,
+            )
+
+            self.uid += 1
+
+    def _extract_lines(self) -> None:
+        for index, row in self.network.line.iterrows():
+            from_bus_index = int(row["from_bus"])
+            to_bus_index = int(row["to_bus"])
+
+            if (
+                from_bus_index not in self.bus_map
+                or to_bus_index not in self.bus_map
+            ):
+                continue
+
+            name = row["name"]
+            if name is None:
+                name = f"Line {index}"
+
+            from_bus = self.bus_map[from_bus_index]
+            to_bus = self.bus_map[to_bus_index]
+
+            # pandapower stores capacitance in nF/km.
+            # GDF stores susceptance in uS/km.
+            b1 = (
+                2
+                * math.pi
+                * self.network.f_hz
+                * float(row["c_nf_per_km"])
+                / 1000
+            )
+
+            r0 = (
+                float(row["r0_ohm_per_km"])
+                if "r0_ohm_per_km" in row
+                and not pd.isna(row["r0_ohm_per_km"])
+                else None
+            )
+
+            x0 = (
+                float(row["x0_ohm_per_km"])
+                if "x0_ohm_per_km" in row
+                and not pd.isna(row["x0_ohm_per_km"])
+                else None
+            )
+
+            b0 = None
+            if (
+                "c0_nf_per_km" in row
+                and not pd.isna(row["c0_nf_per_km"])
+            ):
+                b0 = (
+                    2
+                    * math.pi
+                    * self.network.f_hz
+                    * float(row["c0_nf_per_km"])
+                    / 1000
+                )
+
+            rating = (
+                math.sqrt(3)
+                * from_bus.nominal_voltage
+                * float(row["max_i_ka"])
+            )
+
+            line = TLine(
+                uid=self.uid,
+                name=str(name),
+                length=float(row["length_km"]),
+                r1=float(row["r_ohm_per_km"]),
+                x1=float(row["x_ohm_per_km"]),
+                b1=b1,
+                r0=r0,
+                x0=x0,
+                b0=b0,
+                rating=rating,
+                parallel_lines=int(row["parallel"]),
+            )
+
+            self.core_model.add_component(line)
+            self.line_map[int(index)] = line
+
+            self.core_model.add_connection(
+                line,
+                from_bus,
+                connector_name1="A",
+            )
+
+            self.core_model.add_connection(
+                line,
+                to_bus,
+                connector_name1="B",
+            )
+
+            self.uid += 1
+
+    def _extract_two_winding_transformers(self) -> None:
+        for index, row in self.network.trafo.iterrows():
+            hv_bus_index = int(row["hv_bus"])
+            lv_bus_index = int(row["lv_bus"])
+
+            if (
+                hv_bus_index not in self.bus_map
+                or lv_bus_index not in self.bus_map
+            ):
+                continue
+
+            name = row["name"]
+            if name is None:
+                name = f"Transformer {index}"
+
+            # pandapower gives short-circuit impedance and resistance in percent.
+            r1pu = float(row["vkr_percent"]) / 100
+            z1pu = float(row["vk_percent"]) / 100
+            x1pu = math.sqrt(max(z1pu**2 - r1pu**2, 0.0))
+
+            shift_degree = float(row["shift_degree"])
+            phase_shift_30 = round(shift_degree / 30)
+
+            tap_step_percent = row["tap_step_percent"]
+            tap_changer_voltage = (
+                float(tap_step_percent) / 100
+                if not pd.isna(tap_step_percent)
+                else None
+            )
+
+            transformer = TwoWindingTransformer(
+                uid=self.uid,
+                name=str(name),
+                rating=float(row["sn_mva"]),
+                voltage_hv=float(row["vn_hv_kv"]),
+                voltage_lv=float(row["vn_lv_kv"]),
+                r1pu=r1pu,
+                x1pu=x1pu,
+                pfe_kw=float(row["pfe_kw"]),
+                no_load_current=float(row["i0_percent"]),
+                phase_shift_30=phase_shift_30,
+                tap_changer_voltage=tap_changer_voltage,
+                tap_min=(
+                    int(row["tap_min"])
+                    if not pd.isna(row["tap_min"])
+                    else None
+                ),
+                tap_max=(
+                    int(row["tap_max"])
+                    if not pd.isna(row["tap_max"])
+                    else None
+                ),
+                tap_neutral=(
+                    int(row["tap_neutral"])
+                    if not pd.isna(row["tap_neutral"])
+                    else None
+                ),
+                tap_initial=(
+                    int(row["tap_pos"])
+                    if not pd.isna(row["tap_pos"])
+                    else None
+                ),
+            )
+
+            self.core_model.add_component(transformer)
+            self.trafo_map[int(index)] = transformer
+
+            self.core_model.add_connection(
+                transformer,
+                self.bus_map[hv_bus_index],
+                connector_name1="HV",
+            )
+
+            self.core_model.add_connection(
+                transformer,
+                self.bus_map[lv_bus_index],
+                connector_name1="LV",
+            )
+
+            self.uid += 1
+
+    def _extract_switches(self) -> None:
+        for index, row in self.network.switch.iterrows():
+            bus_index = int(row["bus"])
+
+            if bus_index not in self.bus_map:
+                continue
+
+            name = row["name"]
+            if name is None:
+                name = f"Switch {index}"
+
+            switch_bus = self.bus_map[bus_index]
+            element_index = int(row["element"])
+            element_type = str(row["et"])
+
+            other_component = None
+
+            if element_type == "b":
+                other_component = self.bus_map.get(element_index)
+            elif element_type == "l":
+                other_component = self.line_map.get(element_index)
+            elif element_type == "t":
+                other_component = self.trafo_map.get(element_index)
+
+            if other_component is None:
+                Logger.log_to_selected(
+                    f"Skipping switch '{name}': unsupported or missing "
+                    f"element type '{element_type}' with index {element_index}"
+                )
+                continue
+
+            switch = Switch(
+                uid=self.uid,
+                name=str(name),
+                closed=bool(row["closed"]),
+                in_service=(
+                    bool(row["in_service"])
+                    if "in_service" in row
+                    and not pd.isna(row["in_service"])
+                    else True
+                ),
+            )
+
+            self.core_model.add_component(switch)
+
+            self.core_model.add_connection(
+                switch,
+                switch_bus,
+            )
+
+            self.core_model.add_connection(
+                switch,
+                other_component,
+            )
+
+            self.uid += 1
+
+    def get_core_model(self) -> CoreModel:
+        return self.core_model

--- a/tests/pandapower/pandapower_import_test.py
+++ b/tests/pandapower/pandapower_import_test.py
@@ -1,0 +1,451 @@
+import pandapower
+import math
+import pytest
+from epowcore.gdf.bus import Bus, BusType, LFBusType
+from epowcore.gdf.load import Load
+from epowcore.pandapower.pandapower_converter import PandapowerConverter
+from epowcore.pandapower.pandapower_model import PandapowerModel
+from epowcore.gdf.external_grid import ExternalGrid, ExternalGridType
+from epowcore.gdf.generators.static_generator import StaticGenerator
+from epowcore.gdf.generators.synchronous_machine import SynchronousMachine
+from epowcore.gdf.tline import TLine
+from epowcore.gdf.transformers.two_winding_transformer import TwoWindingTransformer
+from epowcore.gdf.switch import Switch
+import pandapower.networks as pn
+
+def test_import_bus_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    pandapower.create_bus(
+        net,
+        name="Test Bus",
+        vn_kv=20.0,
+        type="b",
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    buses = core_model.type_list(Bus)
+
+    assert len(buses) == 1
+
+    bus = buses[0]
+
+    assert bus.name == "Test Bus"
+    assert bus.nominal_voltage == 20.0
+    assert bus.bus_type == BusType.BUSBAR
+    assert bus.lf_bus_type == LFBusType.PQ
+
+
+def test_import_load_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    bus_index = pandapower.create_bus(
+        net,
+        name="Load Bus",
+        vn_kv=20.0,
+    )
+
+    pandapower.create_load(
+        net,
+        bus=bus_index,
+        name="Test Load",
+        p_mw=5.0,
+        q_mvar=2.0,
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    loads = core_model.type_list(Load)
+    buses = core_model.type_list(Bus)
+
+    assert len(loads) == 1
+    assert len(buses) == 1
+
+    load = loads[0]
+    bus = buses[0]
+
+    assert load.name == "Test Load"
+    assert load.active_power == 5.0
+    assert load.reactive_power == 2.0
+
+    assert core_model.graph.has_edge(load, bus)
+
+def test_import_external_grid_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    bus_index = pandapower.create_bus(
+        net,
+        name="Slack Bus",
+        vn_kv=110.0,
+    )
+
+    pandapower.create_ext_grid(
+        net,
+        bus=bus_index,
+        name="Grid Connection",
+        vm_pu=1.02,
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    external_grids = core_model.type_list(ExternalGrid)
+    buses = core_model.type_list(Bus)
+
+    assert len(external_grids) == 1
+    assert len(buses) == 1
+
+    external_grid = external_grids[0]
+    bus = buses[0]
+
+    assert external_grid.name == "Grid Connection"
+    assert external_grid.u_setp == 1.02
+    assert external_grid.bus_type == ExternalGridType.SL
+
+    assert bus.lf_bus_type == LFBusType.SL
+    assert core_model.graph.has_edge(external_grid, bus)
+
+def test_import_static_generator_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    bus_index = pandapower.create_bus(
+        net,
+        name="Generator Bus",
+        vn_kv=20.0,
+    )
+
+    pandapower.create_sgen(
+        net,
+        bus=bus_index,
+        name="Test Static Generator",
+        p_mw=4.0,
+        q_mvar=1.5,
+        sn_mva=5.0,
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    generators = core_model.type_list(StaticGenerator)
+    buses = core_model.type_list(Bus)
+
+    assert len(generators) == 1
+    assert len(buses) == 1
+
+    generator = generators[0]
+    bus = buses[0]
+
+    assert generator.name == "Test Static Generator"
+    assert generator.active_power == 4.0
+    assert generator.reactive_power == 1.5
+    assert generator.rated_apparent_power == 5.0
+
+    assert core_model.graph.has_edge(generator, bus)
+
+def test_import_synchronous_machine_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    bus_index = pandapower.create_bus(
+        net,
+        name="Generator Bus",
+        vn_kv=110.0,
+    )
+
+    pandapower.create_gen(
+        net,
+        bus=bus_index,
+        name="Test Generator",
+        p_mw=50.0,
+        vm_pu=1.01,
+        sn_mva=60.0,
+        min_p_mw=10.0,
+        max_p_mw=55.0,
+        min_q_mvar=-20.0,
+        max_q_mvar=25.0,
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    generators = core_model.type_list(SynchronousMachine)
+    buses = core_model.type_list(Bus)
+
+    assert len(generators) == 1
+    assert len(buses) == 1
+
+    generator = generators[0]
+    bus = buses[0]
+
+    assert generator.name == "Test Generator"
+    assert generator.active_power == 50.0
+    assert generator.rated_apparent_power == 60.0
+    assert generator.rated_voltage == 110.0
+    assert generator.voltage_set_point == 1.01
+    assert generator.p_min == 10.0
+    assert generator.p_max == 55.0
+    assert generator.q_min == -20.0
+    assert generator.q_max == 25.0
+
+    assert generator.inertia_constant == 4.475
+    assert generator.synchronous_reactance_x == 1.996
+
+    assert core_model.graph.has_edge(generator, bus)
+
+def test_import_line_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    bus_a = pandapower.create_bus(
+        net,
+        name="Bus A",
+        vn_kv=110.0,
+    )
+
+    bus_b = pandapower.create_bus(
+        net,
+        name="Bus B",
+        vn_kv=110.0,
+    )
+
+    pandapower.create_line_from_parameters(
+        net,
+        from_bus=bus_a,
+        to_bus=bus_b,
+        length_km=10.0,
+        r_ohm_per_km=0.1,
+        x_ohm_per_km=0.2,
+        c_nf_per_km=10.0,
+        max_i_ka=0.5,
+        name="Test Line",
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    lines = core_model.type_list(TLine)
+    buses = core_model.type_list(Bus)
+
+    assert len(lines) == 1
+    assert len(buses) == 2
+
+    line = lines[0]
+
+    assert line.name == "Test Line"
+    assert line.length == 10.0
+    assert line.r1 == 0.1
+    assert line.x1 == 0.2
+    assert line.parallel_lines == 1
+
+    assert line.b1 == pytest.approx(
+        2 * math.pi * 50.0 * 10.0 / 1000
+    )
+
+    assert line.rating == pytest.approx(
+        math.sqrt(3) * 110.0 * 0.5
+    )
+
+    assert core_model.graph.has_edge(line, buses[0])
+    assert core_model.graph.has_edge(line, buses[1])
+
+def test_import_two_winding_transformer_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    hv_bus = pandapower.create_bus(
+        net,
+        name="HV Bus",
+        vn_kv=110.0,
+    )
+
+    lv_bus = pandapower.create_bus(
+        net,
+        name="LV Bus",
+        vn_kv=20.0,
+    )
+
+    pandapower.create_transformer_from_parameters(
+        net,
+        hv_bus=hv_bus,
+        lv_bus=lv_bus,
+        name="Test Transformer",
+        sn_mva=40.0,
+        vn_hv_kv=110.0,
+        vn_lv_kv=20.0,
+        vk_percent=10.0,
+        vkr_percent=0.5,
+        pfe_kw=25.0,
+        i0_percent=0.1,
+        shift_degree=30.0,
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    transformers = core_model.type_list(TwoWindingTransformer)
+    buses = core_model.type_list(Bus)
+
+    assert len(transformers) == 1
+    assert len(buses) == 2
+
+    transformer = transformers[0]
+
+    assert transformer.name == "Test Transformer"
+    assert transformer.rating == 40.0
+    assert transformer.voltage_hv == 110.0
+    assert transformer.voltage_lv == 20.0
+    assert transformer.r1pu == pytest.approx(0.005)
+    assert transformer.x1pu == pytest.approx(
+        math.sqrt(0.1**2 - 0.005**2)
+    )
+    assert transformer.pfe_kw == 25.0
+    assert transformer.no_load_current == 0.1
+    assert transformer.phase_shift_30 == 1
+
+    assert core_model.graph.has_edge(transformer, buses[0])
+    assert core_model.graph.has_edge(transformer, buses[1])
+
+def test_import_bus_switch_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    bus_a = pandapower.create_bus(
+        net,
+        name="Bus A",
+        vn_kv=20.0,
+    )
+
+    bus_b = pandapower.create_bus(
+        net,
+        name="Bus B",
+        vn_kv=20.0,
+    )
+
+    pandapower.create_switch(
+        net,
+        bus=bus_a,
+        element=bus_b,
+        et="b",
+        closed=True,
+        name="Test Switch",
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    switches = core_model.type_list(Switch)
+    buses = core_model.type_list(Bus)
+
+    assert len(switches) == 1
+    assert len(buses) == 2
+
+    switch = switches[0]
+
+    assert switch.name == "Test Switch"
+    assert switch.closed is True
+
+    assert core_model.graph.has_edge(switch, buses[0])
+    assert core_model.graph.has_edge(switch, buses[1])
+
+def test_import_line_switch_from_pandapower() -> None:
+    net = pandapower.create_empty_network(
+        f_hz=50.0,
+        sn_mva=100.0,
+    )
+
+    bus_a = pandapower.create_bus(
+        net,
+        name="Bus A",
+        vn_kv=20.0,
+    )
+
+    bus_b = pandapower.create_bus(
+        net,
+        name="Bus B",
+        vn_kv=20.0,
+    )
+
+    line_index = pandapower.create_line_from_parameters(
+        net,
+        from_bus=bus_a,
+        to_bus=bus_b,
+        length_km=1.0,
+        r_ohm_per_km=0.1,
+        x_ohm_per_km=0.2,
+        c_nf_per_km=10.0,
+        max_i_ka=0.4,
+        name="Test Line",
+    )
+
+    pandapower.create_switch(
+        net,
+        bus=bus_a,
+        element=line_index,
+        et="l",
+        closed=False,
+        name="Line Switch",
+    )
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    switches = core_model.type_list(Switch)
+    lines = core_model.type_list(TLine)
+
+    assert len(switches) == 1
+    assert len(lines) == 1
+
+    switch = switches[0]
+    line = lines[0]
+
+    assert switch.name == "Line Switch"
+    assert switch.closed is False
+
+    assert core_model.graph.has_edge(switch, line)
+
+def test_import_pandapower_example_network() -> None:
+    net = pn.simple_four_bus_system()
+
+    core_model = PandapowerConverter().to_gdf(
+        PandapowerModel(network=net)
+    )
+
+    assert len(core_model.type_list(Bus)) == len(net.bus)
+    assert len(core_model.type_list(Load)) == len(net.load)
+    assert len(core_model.type_list(ExternalGrid)) == len(net.ext_grid)
+    assert len(core_model.type_list(TLine)) == len(net.line)
+
+    assert len(core_model.graph.nodes) > 0
+    assert len(core_model.graph.edges) > 0


### PR DESCRIPTION
Adds pandapower → GDF import for all 8 components supported by the existing exporter.
Includes 10 importer tests, including a system test with a pandapower example network.

Core tests: 57 passed, 8 skipped.

Closes #29